### PR TITLE
Add VNC authentication type 2 (VNCAuth)

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ command line option or place it at the default location
 ```
 use_relative_paths=true
 address=0.0.0.0
-enable_auth=true
+require_auth=true
 username=luser
 password=p455w0rd
 private_key_file=tls_key.pem
@@ -163,7 +163,7 @@ You also need to tell wayvnc where this file is located, by setting setting the
 ```
 use_relative_paths=true
 address=0.0.0.0
-enable_auth=true
+require_auth=true
 username=luser
 password=p455w0rd
 rsa_private_key_file=rsa_key.pem
@@ -171,6 +171,27 @@ rsa_private_key_file=rsa_key.pem
 
 You may also add credentials for TLS in combination with RSA. The client will
 choose.
+
+#### VNCAuth
+DES-based authentication does not support encryption and uses weak cryptography
+to protect the password, which is limited to 8 characters. This method does not
+use a username.
+
+To enable VNCAuth, set a password and `relax_encryption`. Do not set
+`enable_pam` and `username`.
+```
+password=p455w0rd
+relax_encryption=true
+```
+
+#### Optional Authentication
+
+Authentication is *enabled* when any of `enable_pam`, `username`, `password` is
+set.
+
+Additionally, authentication is *required* when `require_auth=true` or
+`relax_encryption=false`. Otherwise, authentication is *optional* at client's
+choice.
 
 ### wayvncctl control socket
 

--- a/include/cfg.h
+++ b/include/cfg.h
@@ -20,7 +20,7 @@
 #include <stdint.h>
 
 #define X_CFG_LIST \
-	X(bool, enable_auth) \
+	X(bool, require_auth) \
 	X(bool, relax_encryption) \
 	X(string, private_key_file) \
 	X(string, certificate_file) \

--- a/src/main.c
+++ b/src/main.c
@@ -1101,15 +1101,22 @@ static int init_nvnc(struct wayvnc* self)
 		nvnc_set_desktop_layout_fn(self->nvnc, on_client_resize);
 
 	enum nvnc_auth_flags auth_flags = 0;
-	if (self->cfg.enable_auth) {
+	if (self->cfg.require_auth) {
 		auth_flags |= NVNC_AUTH_REQUIRE_AUTH;
 	}
 	if (!self->cfg.relax_encryption) {
 		auth_flags |= NVNC_AUTH_REQUIRE_ENCRYPTION;
 	}
 
-	if (self->cfg.enable_auth) {
-		if (nvnc_enable_auth(self->nvnc, auth_flags, on_auth, self) < 0) {
+	nvnc_auth_fn auth_fn = NULL;
+#ifdef ENABLE_PAM
+	if (self->cfg.enable_pam)
+		auth_fn = on_auth;
+#endif
+	if (self->cfg.username)
+		auth_fn = on_auth;
+	if (auth_fn || self->cfg.password) {
+		if (nvnc_enable_auth(self->nvnc, auth_flags, auth_fn, self) < 0) {
 			nvnc_log(NVNC_LOG_ERROR, "Failed to enable authentication");
 			goto auth_failure;
 		}
@@ -1138,6 +1145,13 @@ static int init_nvnc(struct wayvnc* self)
 				nvnc_log(NVNC_LOG_ERROR, "Failed to enable TLS authentication");
 				goto auth_failure;
 			}
+		}
+	}
+
+	if (self->cfg.password && self->cfg.relax_encryption && !auth_fn) {
+		if (nvnc_set_password(self->nvnc, self->cfg.password) < 0) {
+			nvnc_log(NVNC_LOG_ERROR, "Failed to set VNCAuth password");
+			goto failure;
 		}
 	}
 
@@ -1396,7 +1410,7 @@ int wayvnc_usage(struct option_parser* parser, FILE* stream, int rc)
 
 int check_cfg_sanity(struct cfg* cfg)
 {
-	if (cfg->enable_auth) {
+	if (cfg->require_auth) {
 		int rc = 0;
 
 		if (!nvnc_has_auth()) {
@@ -1409,13 +1423,13 @@ int check_cfg_sanity(struct cfg* cfg)
 			rc = -1;
 		}
 
-		if (!cfg->username && !cfg->enable_pam) {
-			nvnc_log(NVNC_LOG_ERROR, "Authentication enabled, but missing username");
+		if (!cfg->username && !cfg->enable_pam && !cfg->relax_encryption) {
+			nvnc_log(NVNC_LOG_ERROR, "Authentication required, but missing username");
 			rc = -1;
 		}
 
 		if (!cfg->password && !cfg->enable_pam) {
-			nvnc_log(NVNC_LOG_ERROR, "Authentication enabled, but missing password");
+			nvnc_log(NVNC_LOG_ERROR, "Authentication required, but missing password");
 			rc = -1;
 		}
 
@@ -1424,6 +1438,8 @@ int check_cfg_sanity(struct cfg* cfg)
 		}
 
 		return rc;
+	} else if (cfg->relax_encryption && !cfg->username && !cfg->enable_pam && !cfg->password) {
+		nvnc_log(NVNC_LOG_WARNING, "Authentication enabled but not required; clients will be able to bypass authentication");
 	}
 
 	return 0;

--- a/wayvnc.scd
+++ b/wayvnc.scd
@@ -118,13 +118,7 @@ considered to be part of the key or the value.
 	The address to which the server shall bind, e.g. 0.0.0.0 or localhost.
 
 *certificate_file*
-	The path to the certificate file for encryption. Only applicable when
-	*enable_auth*=true.
-
-*enable_auth*
-	Enable authentication and encryption. Setting this value to *true*
-	requires also setting *certificate_file*, *private_key_file*,
-	*username* and *password*.
+	The path to the certificate file for encryption.
 
 *password*
 	Choose a password for authentication.
@@ -133,16 +127,21 @@ considered to be part of the key or the value.
 	The port to which the server shall bind. Default is 5900.
 
 *private_key_file_file*
-	The path to the private key file for TLS encryption. Only applicable
-	when *enable_auth*=true.
+	The path to the private key file for TLS encryption.
 
 *relax_encryption*
 	Don't require encryption after the user has been authenticated. This
-	enables some security types such as Apple Diffie-Hellman.
+	enables some security types such as Apple Diffie-Hellman and VNCAuth.
+
+*require_auth*
+	Require authentication and encryption. Setting this value to *true*
+	requires also specifying other security options such as
+	*certificate_file*, *enable_pam*, *password*, *private_key_file_file*,
+	*username*. When *require_auth=false*, authentication and encryption may
+	still be enabled by other options, but may be bypassed by clients.
 
 *rsa_private_key_file*
-	The path to the private key file for RSA-AES encryption. Only applicable
-	when *enable_auth*=true.
+	The path to the private key file for RSA-AES encryption.
 
 *username*
 	Choose a username for authentication.
@@ -182,7 +181,7 @@ considered to be part of the key or the value.
 ```
 use_relative_paths=true
 address=0.0.0.0
-enable_auth=true
+require_auth=true
 username=luser
 password=p455w0rd
 rsa_private_key_file=rsa_key.pem


### PR DESCRIPTION
This adds support for VNCAuth (type 2) authentication scheme to wayvnc, leveraging the new functionality in neatvnc. It also changes the behavior with regards to enforcement of authentication options.

VNCAuth is enabled when `password` and `relax_encryption` are set, with no `username` or `enable_pam`.

Authentication is now enabled automatically when any of `enable_pam`, `username` or `password` is set. However, when `relax_encryption=false`, authentication may be optional, i.e. "none" is advertised in addition to other types. This is explicitly controlled by new option `require_auth`, which replaces old option `enable_auth`.

Documentation is updated to reflect new behavior.

Old configuration files that use authentication (`enable_auth=true`) will become incompatible. To get equivalent behavior, replace it with `require_auth=true`.

Old configuration files that don't have `enable_auth` but have other authentication options will be accepted but may start requiring authentication.